### PR TITLE
Dedupe Tempest broadcasts from multiple receiving interfaces

### DIFF
--- a/src/home_weather_hub/tempest_listener.py
+++ b/src/home_weather_hub/tempest_listener.py
@@ -8,11 +8,14 @@ import json
 import logging
 import signal
 import socket
+import time
+from collections.abc import Callable
 from datetime import UTC, date, datetime
 from pathlib import Path
 
 DEFAULT_PORT = 50222
 DEFAULT_FLUSH_INTERVAL_SEC = 5.0
+DEFAULT_DEDUPE_WINDOW_SEC = 2.0
 
 log = logging.getLogger("tempest_listener")
 
@@ -55,15 +58,46 @@ class JsonlWriter:
 
 
 class TempestProtocol(asyncio.DatagramProtocol):
-    def __init__(self, writer: JsonlWriter):
+    def __init__(
+        self,
+        writer: JsonlWriter,
+        dedupe_window_sec: float = DEFAULT_DEDUPE_WINDOW_SEC,
+        time_source: Callable[[], float] = time.monotonic,
+    ):
         self._writer = writer
         self._packet_count = 0
+        self._dropped_dups = 0
+        self._dedupe_window = dedupe_window_sec
+        self._time = time_source
+        # Maps raw datagram bytes -> expiry time (monotonic seconds).
+        self._recent: dict[bytes, float] = {}
 
     def connection_made(self, transport: asyncio.BaseTransport) -> None:
         sock = transport.get_extra_info("socket")
         log.info("listening on %s", sock.getsockname())
 
+    def _is_duplicate(self, data: bytes) -> bool:
+        # Hosts with multiple interfaces on the same broadcast domain receive each
+        # broadcast once per receiving interface; drop bytewise-identical replays
+        # that arrive within the dedupe window.
+        if self._dedupe_window <= 0:
+            return False
+        now = self._time()
+        if self._recent:
+            expired = [k for k, exp in self._recent.items() if exp <= now]
+            for k in expired:
+                del self._recent[k]
+        if data in self._recent:
+            return True
+        self._recent[data] = now + self._dedupe_window
+        return False
+
     def datagram_received(self, data: bytes, addr: tuple[str, int]) -> None:
+        if self._is_duplicate(data):
+            self._dropped_dups += 1
+            if self._dropped_dups % 100 == 1:
+                log.info("dropped %d duplicate packet(s) so far", self._dropped_dups)
+            return
         try:
             payload = json.loads(data)
         except json.JSONDecodeError as e:
@@ -92,11 +126,11 @@ async def _flush_loop(writer: JsonlWriter, interval: float) -> None:
         writer.flush()
 
 
-async def _run(port: int, data_dir: Path, flush_interval: float) -> None:
+async def _run(port: int, data_dir: Path, flush_interval: float, dedupe_window: float) -> None:
     writer = JsonlWriter(data_dir)
     loop = asyncio.get_running_loop()
     transport, _ = await loop.create_datagram_endpoint(
-        lambda: TempestProtocol(writer),
+        lambda: TempestProtocol(writer, dedupe_window_sec=dedupe_window),
         local_addr=("0.0.0.0", port),
         family=socket.AF_INET,
         allow_broadcast=True,
@@ -120,6 +154,12 @@ def main() -> None:
     parser.add_argument("--port", type=int, default=DEFAULT_PORT)
     parser.add_argument("--data-dir", type=Path, default=Path("./data"))
     parser.add_argument("--flush-interval", type=float, default=DEFAULT_FLUSH_INTERVAL_SEC)
+    parser.add_argument(
+        "--dedupe-window",
+        type=float,
+        default=DEFAULT_DEDUPE_WINDOW_SEC,
+        help="Drop bytewise-identical packets seen within this many seconds. Set to 0 to disable.",
+    )
     parser.add_argument("--log-level", default="INFO")
     args = parser.parse_args()
 
@@ -127,7 +167,7 @@ def main() -> None:
         level=args.log_level.upper(),
         format="%(asctime)s %(levelname)s %(name)s: %(message)s",
     )
-    asyncio.run(_run(args.port, args.data_dir, args.flush_interval))
+    asyncio.run(_run(args.port, args.data_dir, args.flush_interval, args.dedupe_window))
 
 
 if __name__ == "__main__":

--- a/tests/integration/test_udp_capture.py
+++ b/tests/integration/test_udp_capture.py
@@ -15,11 +15,11 @@ from home_weather_hub.tempest_listener import JsonlWriter, TempestProtocol
 pytestmark = pytest.mark.integration
 
 
-async def _bring_up_listener(port: int, data_dir: Path):
+async def _bring_up_listener(port: int, data_dir: Path, dedupe_window_sec: float = 2.0):
     writer = JsonlWriter(data_dir)
     loop = asyncio.get_running_loop()
     transport, _ = await loop.create_datagram_endpoint(
-        lambda: TempestProtocol(writer),
+        lambda: TempestProtocol(writer, dedupe_window_sec=dedupe_window_sec),
         local_addr=("127.0.0.1", port),
         family=socket.AF_INET,
         allow_broadcast=True,
@@ -83,3 +83,33 @@ async def test_listener_survives_mix_of_good_and_bad_packets(
 
     types = [json.loads(line)["payload"]["type"] for line in target.read_text().splitlines()]
     assert types == ["obs_st", "rapid_wind"]
+
+
+async def test_listener_dedupes_back_to_back_identical_packets(
+    free_udp_port: int, tmp_path: Path
+) -> None:
+    """Simulates the multi-interface broadcast scenario: identical bytes arrive
+    multiple times in quick succession; only one should be persisted."""
+    transport, writer = await _bring_up_listener(free_udp_port, tmp_path, dedupe_window_sec=2.0)
+    try:
+        pkt = b'{"type":"hub_status","serial_number":"DUP-INT","seq":1}'
+        for _ in range(4):
+            _send_udp(pkt, free_udp_port)
+
+        target = tmp_path / f"tempest-{datetime.now(UTC).date().isoformat()}.jsonl"
+        for _ in range(50):
+            await asyncio.sleep(0.01)
+            writer.flush()
+            if target.exists() and target.stat().st_size > 0:
+                break
+        # Give the loop extra ticks so any *non*-deduped duplicates would land.
+        for _ in range(20):
+            await asyncio.sleep(0.01)
+            writer.flush()
+    finally:
+        transport.close()
+        writer.close()
+
+    lines = target.read_text().splitlines()
+    assert len(lines) == 1, f"expected exactly one record after dedupe, got {len(lines)}"
+    assert json.loads(lines[0])["payload"]["serial_number"] == "DUP-INT"

--- a/tests/unit/test_tempest_protocol.py
+++ b/tests/unit/test_tempest_protocol.py
@@ -67,3 +67,84 @@ def test_record_envelope_keys() -> None:
     proto = TempestProtocol(writer)  # type: ignore[arg-type]
     proto.datagram_received(b'{"type":"x"}', ("10.0.0.1", 50222))
     assert set(writer.records[0].keys()) == {"received_at", "src_addr", "payload"}
+
+
+def test_dedupe_drops_identical_bytes_within_window() -> None:
+    """Multiple interfaces on the same broadcast domain deliver the same packet
+    twice; the second copy should be dropped."""
+    fake_clock = [1000.0]
+    writer = RecordingWriter()
+    proto = TempestProtocol(
+        writer,  # type: ignore[arg-type]
+        dedupe_window_sec=2.0,
+        time_source=lambda: fake_clock[0],
+    )
+    pkt = b'{"type":"hub_status","seq":42}'
+    proto.datagram_received(pkt, ("192.168.5.232", 50222))
+    fake_clock[0] += 0.001  # microseconds later, second interface delivers
+    proto.datagram_received(pkt, ("192.168.5.233", 50222))
+    assert len(writer.records) == 1
+    assert writer.records[0]["payload"] == {"type": "hub_status", "seq": 42}
+
+
+def test_dedupe_allows_identical_bytes_after_window_expires() -> None:
+    fake_clock = [1000.0]
+    writer = RecordingWriter()
+    proto = TempestProtocol(
+        writer,  # type: ignore[arg-type]
+        dedupe_window_sec=2.0,
+        time_source=lambda: fake_clock[0],
+    )
+    pkt = b'{"type":"rapid_wind","ob":[1,2,3]}'
+    proto.datagram_received(pkt, ("192.168.5.232", 50222))
+    fake_clock[0] += 2.5  # well past the window
+    proto.datagram_received(pkt, ("192.168.5.232", 50222))
+    assert len(writer.records) == 2
+
+
+def test_dedupe_does_not_collapse_distinct_payloads() -> None:
+    """Real distinct observations differ byte-for-byte and must not be deduped."""
+    fake_clock = [1000.0]
+    writer = RecordingWriter()
+    proto = TempestProtocol(
+        writer,  # type: ignore[arg-type]
+        dedupe_window_sec=2.0,
+        time_source=lambda: fake_clock[0],
+    )
+    proto.datagram_received(b'{"type":"hub_status","seq":1}', ("192.168.5.232", 50222))
+    fake_clock[0] += 0.5
+    proto.datagram_received(b'{"type":"hub_status","seq":2}', ("192.168.5.232", 50222))
+    fake_clock[0] += 0.5
+    proto.datagram_received(b'{"type":"hub_status","seq":3}', ("192.168.5.232", 50222))
+    assert len(writer.records) == 3
+    assert [r["payload"]["seq"] for r in writer.records] == [1, 2, 3]
+
+
+def test_dedupe_disabled_when_window_is_zero() -> None:
+    writer = RecordingWriter()
+    proto = TempestProtocol(writer, dedupe_window_sec=0.0)  # type: ignore[arg-type]
+    pkt = b'{"type":"hub_status"}'
+    proto.datagram_received(pkt, ("192.168.5.232", 50222))
+    proto.datagram_received(pkt, ("192.168.5.233", 50222))
+    assert len(writer.records) == 2
+
+
+def test_dedupe_cache_prunes_expired_entries() -> None:
+    """Cache must shed stale entries so it doesn't grow unbounded."""
+    fake_clock = [1000.0]
+    writer = RecordingWriter()
+    proto = TempestProtocol(
+        writer,  # type: ignore[arg-type]
+        dedupe_window_sec=1.0,
+        time_source=lambda: fake_clock[0],
+    )
+    for i in range(5):
+        proto.datagram_received(f'{{"i":{i}}}'.encode(), ("192.168.5.232", 50222))
+        fake_clock[0] += 0.1
+    assert len(proto._recent) == 5  # type: ignore[attr-defined]
+
+    fake_clock[0] += 5.0  # blow past the window for everything
+    proto.datagram_received(b'{"trigger":"prune"}', ("192.168.5.232", 50222))
+    # After the next insert, all 5 prior entries should have been pruned;
+    # only the freshly inserted one remains.
+    assert len(proto._recent) == 1  # type: ignore[attr-defined]


### PR DESCRIPTION
**Stacked on #1.** Base = \`feat/tempest-udp-listener\`. Once #1 merges, GitHub will retarget this PR to \`main\` automatically.

## Problem
Hosts with two interfaces on the same broadcast domain (en0 + en1 on the same /22 here) receive each Tempest broadcast once per interface. A wildcard-bound UDP socket sees both copies, so every packet was being persisted twice — silently doubling JSONL row counts. Confirmed live: the deployment Mac has both en0 (192.168.5.232) and en1 (192.168.5.233) up on the same broadcast domain, and every packet appeared in pairs at the same timestamp.

## Fix
Add a small bytewise-keyed dedupe cache to \`TempestProtocol\`. Default window 2.0s — long enough to absorb multi-interface delivery skew (microseconds in practice) but well below the shortest legitimate packet cadence (\`rapid_wind\` at 3s). Real distinct observations differ byte-for-byte (timestamps, seq, sensor values) so they are never collapsed.

- Configurable via \`--dedupe-window\` (set to 0 to disable)
- Cache prunes expired entries on each insert; bounded by traffic rate × window
- Time source is injectable (\`time_source\` param) so unit tests can advance the clock without sleeping
- Logs \`"dropped N duplicate packet(s) so far"\` periodically so operators notice the condition

## Test plan
- [x] 5 new unit tests in \`tests/unit/test_tempest_protocol.py\`: dedupes within window, allows after window expires, doesn't collapse distinct payloads, disabled at \`window=0\`, prunes the cache
- [x] 1 new integration test: 4 back-to-back identical UDP datagrams produce exactly 1 record on disk
- [x] Live verification against the real hub: 30s capture produced single-cadence counts (14 \`rapid_wind\`, 4 \`hub_status\`, 1 \`obs_st\`, 1 \`device_status\`) instead of the previous 2x rate, and the listener log shows \`"dropped 1 duplicate packet(s) so far"\`
- [x] Full suite: \`uv run pytest\` → 19 passed in 0.71s
- [x] \`uv run ruff check .\` clean; \`ruff format --check .\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)