### PR TITLE
Wire CLAUDE_CODE_OAUTH_TOKEN into Claude PR Assistant

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -30,3 +30,5 @@ jobs:
 
       - name: Run Claude Code
         uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}


### PR DESCRIPTION
## Summary
- The Claude PR Assistant action was running with an empty `ANTHROPIC_API_KEY` and failing on every \`@claude\` mention. (See PR #4 — every \`@claude\` comment produced a failed run.)
- Wires the existing repo secret `CLAUDE_CODE_OAUTH_TOKEN` into \`anthropics/claude-code-action@v1\` so it can authenticate against your Claude Max subscription instead of billed API usage.

## Setup required (you, before merge)
Generate the OAuth token and add it as a repo secret:
\`\`\`sh
claude setup-token
gh secret set CLAUDE_CODE_OAUTH_TOKEN --repo tommyroar/home-weather-hub
\`\`\`

## Test plan
- [ ] Set the \`CLAUDE_CODE_OAUTH_TOKEN\` repo secret
- [ ] Merge this PR
- [ ] Comment \`@claude do you see this?\` on any PR
- [ ] Confirm the Claude PR Assistant run succeeds and a Claude reply appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)