### PR TITLE
docs: the weather hub moves into Home Assistant

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,20 +7,24 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 Live local-network climate dashboard for Tommy's home. Three data planes feed one web app:
 
 - **Outside weather** — [Tempest](https://shop.tempest.earth/products/tempest) station broadcasts UDP packets on the LAN. Listener must bind to the broadcast port and decode Tempest's JSON message types (e.g. `obs_st`, `rapid_wind`, `evt_strike`).
-- **Inside climate** — Zigbee sensors publish to a local MQTT broker. Subscriber consumes those topics.
+- **Inside climate** — Zigbee temp/humidity sensors pair to **Home Assistant** via the **ZHA** integration (Sonoff Zigbee 3.0 USB Dongle Plus V2 on the HA Pi at `homeassistant.local` / `192.168.4.101`). HA archives readings to InfluxDB through its built-in `influxdb` integration. **(2026-06 pivot — this replaces the original "local MQTT broker + custom subscriber" plan; there is no MQTT broker or subscriber in this repo. ZHA was set up after migrating HAOS from SD card to the USB drive; see `FLASH.md`.)**
 - **Dashboard** — Containerized web app served from a Mac Mini M1 on the local network. Stretch: live webcam co-sited with the Tempest as the dashboard background.
 
 The deployment target (Mac Mini M1, LAN-only, Apple Silicon container runtime) shapes most architectural choices — keep images `linux/arm64`-compatible and prefer OrbStack-friendly compose setups over anything that assumes cloud infra.
 
+> **Tempest ingest — unified to HA (done 2026-06-14):** Tempest now flows **Home Assistant `weatherflow` (device `st_00204728`) → HA `influxdb` integration → `home_assistant` bucket**, in HA display units (°F, inHg, mph, mi). The Grafana "Tempest — Basic" dashboard and the `freshness-tempest` alert were repointed to `home_assistant` (`sensor.st_00204728_*`, field `value`). The Mac `infra/tempest-bridge` launchd job (`dev.tommydoerr.tempest-bridge`) was **retired** (booted out + disabled; plist kept as `.retired`). The old **`tempest_archive`** bucket is a **frozen, R2-backed historical archive** (no backfill); only the two per-strike lightning-event panels still read it (HA doesn't expose strike energy/per-strike events). This repo's standalone `tempest_listener.py` → JSONL + SQLite remains **dormant** and is now superseded — don't run it against the live broadcast.
+
 ## Stack
 
-- **Python 3.12+** managed by **`uv`** for the ingest side (UDP listener, MQTT subscriber, eventually the dashboard backend). Single src-layout package: `src/home_weather_hub/`.
+- **Python 3.12+** managed by **`uv`** for the Tempest ingest side (UDP listener, and eventually the dashboard backend). Single src-layout package: `src/home_weather_hub/`. *(The once-planned MQTT subscriber is dropped — indoor Zigbee now lands in InfluxDB via Home Assistant/ZHA, not this package.)*
 - The dashboard frontend is not yet built; if/when added it will likely be Vite (the gitignore is already Vite-flavored).
 - Captured raw data lands in `./data/*.jsonl` (gitignored), one packet per line, daily-rotated. Decoded `obs_st` values also flow into a SQLite store at `./data/weather.db` (see below).
 
 ## Storage architecture
 
 Two parallel sinks. JSONL is the immutable audit/replay corpus; SQLite is the query surface for the dashboard.
+
+> **Scope note (2026-06):** this SQLite store is currently **Tempest-only**. Indoor Zigbee climate is no longer destined here — it's archived in InfluxDB via Home Assistant/ZHA (see the Project section). The sensor-agnostic `(sensor_id, metric)` schema and the `snzb:<ieee>` sensor-kind below are kept as a still-valid design for *replaying* Zigbee data into SQLite if ever wanted, but they're not on the live path.
 
 - **JSONL** (`data/tempest-YYYY-MM-DD.jsonl`) — raw packets wrapped in `{received_at, src_addr, payload}`. Captures everything (`obs_st`, `rapid_wind`, `hub_status`, `device_status`, events). Replayable.
 - **SQLite WAL** (`data/weather.db`) — four tables, all keyed on a sensor-agnostic `(sensor_id, metric)` schema so future Zigbee/MQTT data drops in without migrations:

--- a/FLASH.md
+++ b/FLASH.md
@@ -1,0 +1,217 @@
+# Migrate running HAOS from SD card to USB storage drive
+
+Task list for migrating the **live** Home Assistant OS instance off its current
+Raspberry Pi SD card and onto the newly-arrived USB storage drive, driven from
+`tommys-mac-mini` (macOS, Apple Silicon). The strategy is backup-flash-restore:
+take a full HA backup off-device, flash a **clean** HAOS image to the new drive,
+swap hardware, and restore the backup during onboarding. The SD card stays intact
+as the rollback path until the new drive is verified.
+
+> Sibling doc: `flash_pi.md` covers a from-scratch HAOS bootstrap. This doc reuses
+> its flashing mechanics (§4 there) but adds the backup/restore wrapper that makes
+> it a *migration* rather than a clean install.
+
+## Hardware
+
+- **Current boot media:** microSD card running HAOS (to be retired, kept as rollback)
+- **Target media:** **Raspberry Pi-branded 128 GB USB storage drive** — detected
+  2026-06-07 at `/dev/disk7`, USB (negotiated 480 Mb/s / USB 2.0), factory
+  MBR/`Windows_NTFS` format (volume `Untitled`), VID:PID `2e8a:0030`,
+  serial `0325900001DA`. Capacity 128.4 GB (128,379,256,832 bytes).
+  > Device node (`disk7`) can change across re-plugs — match on the size/format/serial
+  > signature above, never on the number alone. **Re-run §5's `diskutil list external`
+  > and re-confirm before writing.**
+- **DO NOT TOUCH:** `/dev/disk4` = `WD_BLACK SN850X 2000GB` (2 TB NVMe) is the
+  `/Volumes/dev` workspace disk. It is never a flash target. Flashing it destroys this
+  entire workspace.
+- **Target host:** Raspberry Pi 4 Model B, 4GB RAM
+- **Connection:** new drive into a **blue** USB 3.0 port on the Pi for first boot
+  (the drive itself negotiates USB 2.0 speed, so first-boot OTA will be on the slower side)
+- **Workstation:** `tommys-mac-mini` (macOS, Apple Silicon)
+- **Network:** Pi on wired Ethernet; `homeassistant.local` → **192.168.4.101**,
+  web UI at `http://homeassistant.local:8123` (confirmed reachable)
+- **Image:** reuse `~/Downloads/haos_rpi4-64-17.3.img.xz`
+  (sha256 `371af52e378d94bbe0391ad7fb49848a94443336c168c5848cbff66923afbb25`),
+  or fetch a newer stable if one has shipped — match the **running** instance's
+  major version or newer, never older (restore won't downgrade cleanly).
+
+## SSH / access (probed 2026-06-07)
+
+| Endpoint | Port | State | Use |
+|---|---|---|---|
+| Web UI | `8123` | **open** | Backups UI, onboarding, restore |
+| SSH add-on (Terminal & SSH / Web Terminal) | `22` | **open** | `ssh root@homeassistant.local` → `ha` CLI + `/backup` access |
+| HAOS host debug SSH | `22222` | **closed** | Not enabled — don't rely on it |
+
+So the CLI/scp paths below go through the **SSH add-on on port 22** (login user is
+typically `root` with the key/password configured in the add-on options), **not** the
+host debug port `22222`. If port 22 auth fails, the add-on may use a non-`root` username
+or key-only auth — check the add-on's configuration. Everything here can also be done
+entirely from the **web UI** if SSH is inconvenient.
+
+## Guiding principle — order of operations is the safety net
+
+**Nothing destructive happens until a verified backup is sitting on the Mac (and
+off-host in R2).** The SD card is never wiped during this migration; it is the
+rollback. If anything goes wrong, re-insert the SD card and power on — you are
+back to the known-good state in two minutes.
+
+## Tasks
+
+### 1. Create a full backup on the running Pi
+
+- [ ] Confirm HA is reachable: `curl -s -o /dev/null -w "%{http_code}" --max-time 5 http://homeassistant.local:8123`
+- [ ] Trigger a **full** backup (config + add-ons + add-on data + media). Pick one:
+  - **UI:** Settings → System → Backups → **Create backup** → *Full backup*.
+  - **CLI** (via the SSH add-on on port 22): `ssh root@homeassistant.local`, then
+    `ha backups new --name "pre-ssd-migration"` and `ha backups list`.
+- [ ] Note the resulting backup **slug** and filename (`<slug>.tar` under `/backup`).
+- [ ] Record the backup's reported size and the entity/add-on count shown in the UI
+      so the post-restore verification (§8) has something to check against.
+
+### 2. Pull the backup down to the Mac ("sync to this machine")
+
+- [ ] Choose a transport (recommended first):
+  - **UI download (simplest):** in the Backups list, ⋮ → **Download backup** → lands
+    in `~/Downloads/`. Then move it: `mv ~/Downloads/<slug>.tar /Volumes/dev/home-weather-hub/data/haos-backups/`.
+  - **scp over the SSH add-on** (port 22 — host debug `22222` is disabled):
+    `scp root@homeassistant.local:/backup/<slug>.tar /Volumes/dev/home-weather-hub/data/haos-backups/`
+    (the add-on maps the `backup` share, so `/backup/<slug>.tar` is reachable)
+  - **Samba add-on share:** mount `\\homeassistant\backup`, copy `<slug>.tar` off.
+- [ ] Create the local landing dir if missing: `mkdir -p /Volumes/dev/home-weather-hub/data/haos-backups`
+      (this lives under the gitignored `data/` tree — backups are never committed).
+- [ ] **Verify the copy is intact**, not truncated:
+  - `ls -lh /Volumes/dev/home-weather-hub/data/haos-backups/<slug>.tar` (size matches §1)
+  - `tar tf <slug>.tar >/dev/null && echo "archive OK"` (lists without error)
+  - Record `shasum -a 256 <slug>.tar` for later re-verification.
+
+### 3. Push a copy off-host (the "remotely" leg)
+
+- [ ] Mirror the existing InfluxDB→R2 pattern (`infra/influxdb/backup-r2-sync.sh`):
+      push the backup to a Cloudflare R2 bucket so a copy survives loss of both the
+      Pi and the Mac.
+- [ ] If no `haos-backups` bucket exists yet, create one and reuse the R2 creds
+      already in `/Volumes/dev/influxdb/.env` (Object Read & Write):
+  ```sh
+  source /Volumes/dev/influxdb/.env
+  export RCLONE_CONFIG_R2_TYPE=s3 RCLONE_CONFIG_R2_PROVIDER=Cloudflare \
+    RCLONE_CONFIG_R2_ACCESS_KEY_ID="$R2_ACCESS_KEY_ID" \
+    RCLONE_CONFIG_R2_SECRET_ACCESS_KEY="$R2_SECRET_ACCESS_KEY" \
+    RCLONE_CONFIG_R2_ENDPOINT="https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com"
+  rclone copy /Volumes/dev/home-weather-hub/data/haos-backups/<slug>.tar r2:haos-backups
+  rclone lsf r2:haos-backups        # confirm it's up there
+  ```
+- [ ] **Gate:** do not advance past this step until the backup is confirmed in
+      **both** places (Mac + R2). This is the point of no concern — from here, even a
+      botched flash can't lose data.
+
+### 4. Pre-flight the flash
+
+- [ ] Confirm `rpi-imager` present: `brew list raspberry-pi-imager || brew install --cask raspberry-pi-imager` (ask before installing).
+- [ ] Re-verify the image digest before writing:
+      `shasum -a 256 ~/Downloads/haos_rpi4-64-17.3.img.xz` matches the recorded sha256.
+- [ ] Ask Tommy to confirm the new storage drive is plugged into the Mac; wait for confirmation.
+
+### 5. Identify the target drive — **destructive, confirm explicitly**
+
+- [ ] `diskutil list external` and parse output.
+- [ ] **Expected target signature** (re-verify, device node may have changed):
+      128.4 GB · USB · MBR/`Windows_NTFS` (volume `Untitled`) · Manufacturer
+      `Raspberry Pi` · serial `0325900001DA`. As of 2026-06-07 this was `/dev/disk7`.
+      Confirm with: `diskutil info /dev/diskN | grep -Ei 'Media Name|Disk Size|Protocol'`
+      and `system_profiler SPUSBDataType | grep -A6 'Flash Drive'` (serial should match).
+- [ ] **Hard exclusion:** `/dev/disk4` (`WD_BLACK SN850X 2000GB`, 2 TB, PCI-Express) is
+      `/Volumes/dev` — **never** a target. If the candidate is 2 TB or PCI-Express, STOP.
+- [ ] **Print the resolved device identifier plus name/size and require an explicit
+      `yes` before any write.**
+- [ ] If multiple external drives are present, list them and ask which one.
+- [ ] **NEVER write without explicit confirmation of the target device.** The Mac's
+      internal disk, the 2 TB workspace disk, and any backup drives must never be candidates.
+
+### 6. Flash the new drive
+
+- [ ] Unmount first: `diskutil unmountDisk <device>` (not `eject`).
+- [ ] Write the image. Prefer `rpi-imager` CLI; fall back to `xz -dc <image> | sudo dd of=/dev/rdiskN bs=4m status=progress`
+      using the **raw** device (`/dev/rdiskN`) for ~5× speed on macOS.
+- [ ] Print every `sudo` command and its effect before running it.
+- [ ] On completion: `sync`, then `diskutil eject <device>`.
+
+### 7. Swap — power-down order matters
+
+Do these **in order**. Do not skip the graceful shutdown; pulling power on a live
+HAOS risks a corrupt filesystem on the SD card you may still need.
+
+1. [ ] **Graceful software shutdown of HA** — UI: Settings → System → top-right
+       power icon → **Shut down system** (or `ha host shutdown` over SSH).
+2. [ ] **Wait for the Pi's green activity LED to go dark** (disk flushed). Give it ~30s.
+3. [ ] **Unplug the Pi's power** (no soft power button — pulling power is the off switch,
+       but only *after* the shutdown above has quiesced the disk).
+4. [ ] **Remove the microSD card.** Set it aside, label it "HAOS rollback — DO NOT WIPE".
+       Removing it is required: a Pi 4 with an SD card present will boot the SD, not USB.
+5. [ ] **Connect the freshly-flashed USB drive** to a **blue USB 3.0** port on the Pi.
+6. [ ] Confirm Ethernet is connected.
+7. [ ] **Plug the Pi's power back in.** First boot pulls an OTA update and resizes the
+       filesystem — 5–15 min, **do not interrupt power**.
+
+> USB-boot caveat: Pi 4 USB mass-storage boot needs a reasonably current bootloader
+> EEPROM (standard since 2020; if HAOS already runs on this Pi it's almost certainly
+> fine). If it doesn't boot with the SD removed, re-insert the SD to recover, then
+> update the EEPROM (`rpi-eeprom`) before retrying — and reach for `flash_pi.md`'s
+> troubleshooting (§7 there).
+
+### 8. Bring it online and restore
+
+- [ ] Poll for HAOS: `curl -s -o /dev/null -w "%{http_code}" --max-time 5 http://homeassistant.local:8123`
+      every 30s, up to 20 min. Success = 200 or redirect to `/onboarding/`.
+- [ ] At the onboarding screen, choose **"Restore from backup"** → upload the
+      `<slug>.tar` from `/Volumes/dev/home-weather-hub/data/haos-backups/` (or restore
+      from the Pi's `/backup` share if you copied it back). Select **full** restore.
+- [ ] Wait for the restore + reboot to complete.
+
+### 9. Verify the migration
+
+- [ ] HA reachable and you can log in with the **existing** credentials (not a fresh account — restore brings them).
+- [ ] **Confirm it booted from USB, not SD:** the SD is physically out, so simply
+      being online proves USB boot. Optionally check Settings → System → Storage (or
+      `ha host info`) shows the larger drive's capacity.
+- [ ] Entity count / dashboards / add-ons match the pre-migration figures from §1.
+- [ ] Add-ons are **running** (Settings → Add-ons) — not just installed.
+- [ ] Integrations reconnected: MQTT/Zigbee sensors reporting, recorder writing history.
+- [ ] If the InfluxDB integration is in use (see `infra/README.md` migration target),
+      confirm it's still pushing to the Mac's InfluxDB buckets.
+- [ ] Set a DHCP reservation for the Pi's MAC if not already done.
+
+## Acceptance criteria
+
+- [ ] Full backup created, pulled to the Mac, **and** mirrored to R2 — verified intact in both.
+- [ ] New drive flashed without writing to any other disk.
+- [ ] Pi gracefully shut down, SD removed and preserved, booted from the USB drive.
+- [ ] `http://homeassistant.local:8123` returns 200 within 20 min of power-on.
+- [ ] Backup restored; entities, add-ons, and integrations match the pre-migration state.
+- [ ] SD card retained untouched as rollback.
+
+## Safety notes
+
+- **The SD card is the rollback — never wipe it during this migration.** Retire it
+  only after the new drive has run clean for a few days.
+- **Verified backup before any flash.** §3's gate is non-negotiable.
+- **Destructive flash:** require explicit confirmation of the target device identifier
+  before any `dd` / `rpi-imager` write. Print every `sudo` command first.
+- **Graceful shutdown before pulling power** — protects the SD's filesystem.
+- Use the official Pi PSU; a USB SSD can draw more than a flash stick and brownouts
+  cause boot loops.
+
+## Rollback
+
+If the new drive fails to boot or the restore is bad:
+
+1. Pull Pi power, remove the USB drive.
+2. Re-insert the original SD card.
+3. Power on — back to the pre-migration instance within a couple of minutes.
+4. Investigate (EEPROM, drive health, image integrity) before retrying §6.
+
+## Out of scope
+
+- Onboarding a *new* HA instance from scratch (that's `flash_pi.md`).
+- HACS / integration setup beyond what the restore brings back.
+- Repurposing or wiping the old SD card.

--- a/infra/README.md
+++ b/infra/README.md
@@ -10,7 +10,7 @@ Snapshot of the live home-stack infrastructure on `tommys-mac-mini`. **These fil
 |---|---|---|---|
 | InfluxDB 2.7 | `influxdb:2.7-alpine` (OrbStack) | `/Volumes/dev/influxdb/` | `8086` |
 | Grafana 11.3 | `grafana/grafana-oss:11.3.0` (OrbStack) | `/Volumes/dev/grafana/` | host `3001` → container `3000` |
-| Tempest UDP→InfluxDB bridge | Python 3 via launchd | `~/.local/share/tempest-bridge/` | UDP `50222` listener |
+| ~~Tempest UDP→InfluxDB bridge~~ **(retired 2026-06-14)** | Python 3 via launchd | `~/.local/share/tempest-bridge/` (plist now `.retired`) | superseded by HA weatherflow→influxdb |
 | InfluxDB daily backup | shell script via launchd | `/Volumes/dev/influxdb/backup.sh` | n/a (03:30 daily) |
 | InfluxDB → R2 off-host sync | shell script via launchd | `/Volumes/dev/influxdb/backup-r2-sync.sh` | n/a (04:00 daily) |
 
@@ -149,6 +149,10 @@ PATH="/opt/homebrew/opt/node@24/bin:$PATH" npx playwright test
 - **OrbStack port forwards can wedge on restart.** Grafana publishes host port `3001` → container `3000` because port `3000` got stuck in a "bind: address already in use" loop after an earlier restart. Switch back when convenient.
 - **Drift risk.** Changes made in-place at runtime paths won't update this repo. Best practice: edit here, copy to runtime, restart the affected service.
 
-## Migration target
+## Migration target — Tempest done (2026-06-14)
 
-The whole stack is a stopgap until Home Assistant on the Raspberry Pi takes over outdoor/indoor sensor capture. At that point: tear down the Tempest bridge, point HA's InfluxDB integration at the existing InfluxDB on this Mac, and let HA push to the `home_assistant` and `zigbee_archive` buckets. The Grafana datasources are already pre-wired for that handoff.
+The whole stack is a stopgap until Home Assistant on the Raspberry Pi takes over outdoor/indoor sensor capture.
+
+**Tempest handoff complete:** HA's `weatherflow` integration (device `st_00204728`) now exports to InfluxDB's `home_assistant` bucket via HA's `influxdb` integration (`measurement_attr: entity_id`, so each metric is `sensor.st_00204728_<x>`/`value`, in HA display units). The `tempest-bridge` launchd job was **retired** (booted out + disabled; plist kept as `.retired`). The Grafana `Tempest — Basic` dashboard, the `freshness-tempest` alert, and the ops freshness/status panels were repointed to `home_assistant`. The `tempest_archive` bucket is now a **frozen historical archive** (no backfill; R2-backed) — only the two per-strike lightning panels still read it.
+
+**Still pending:** the indoor/Zigbee side now runs through HA's **ZHA** integration (Sonoff dongle) → `home_assistant` bucket as sensors are paired; `zigbee_archive` is reserved for that. The bridge teardown above is the outdoor half.


### PR DESCRIPTION
`HOME-WEATHER-HUB` — **DOCS DISPATCH**

# The weather hub moves into Home Assistant

> _Runbook and doc updates for the session that migrated HAOS from SD card to USB, stood up Zigbee via ZHA, and unified Tempest ingest under Home Assistant._

> [!NOTE]
> **docs** · docs · risk: none

This session moved the home climate stack onto Home Assistant: HAOS migrated off its SD card onto the new USB drive, ZHA came up on the Sonoff dongle, and Tempest ingest collapsed from a bespoke Mac bridge into HA's native `weatherflow` → InfluxDB export. This PR makes the repo's docs match that running reality.

## What changed
- **`FLASH.md`** (new) — runbook for migrating the running HAOS off its SD card onto the USB storage drive: backup → flash → swap → restore, SD kept as rollback, with the power-down order and verification steps.
- **`CLAUDE.md`** — indoor climate is now **HA ZHA** (Sonoff Zigbee 3.0 dongle) → InfluxDB, replacing the old local-MQTT-broker + subscriber plan; Tempest ingest **unified to HA** (Mac bridge retired 2026-06-14); the SQLite store noted as Tempest-only.
- **`infra/README.md`** — Tempest migration target marked **done**; the `tempest-bridge` row marked retired.

> _"The docs now describe the system that exists, not the one we planned."_

## Companion change
The Grafana/alerting half of the Tempest cutover (dashboard + freshness alert repointed to the `home_assistant` bucket) ships in **observability-config #96**. This is the home-weather-hub half.

## How it flows
No flow change — documentation only; the runtime flow it documents is diagrammed in observability-config #96.

## Verification
- Pure docs: `FLASH.md` added, `CLAUDE.md` + `infra/README.md` edited; no code touched.
- Cross-checked against the live system: HAOS on USB, ZHA `loaded`, Tempest writing to `home_assistant`.

## Risk & rollout
- Docs-only; no runtime impact. The migration + cutover described are already live and verified.
