### PR TITLE
chore: rename github URLs tommyroar → robogeosociety

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,6 +1,6 @@
 name: Claude PR Assistant
 
-# Canonical @claude responder — source of truth: tommyroar/.github.
+# Canonical @claude responder — source of truth: robogeosociety/.github.
 # Synced into every owned repo by scripts/sync.sh. Also selectable one-click
 # from the Actions "New workflow" UI. Auth: CLAUDE_CODE_OAUTH_TOKEN (Max sub).
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-# Canonical pre-commit config — source of truth: tommyroar/.github, synced by scripts/sync.sh.
+# Canonical pre-commit config — source of truth: robogeosociety/.github, synced by scripts/sync.sh.
 # One-time per clone:   uv tool install pre-commit && pre-commit install
 # Ruff version here is kept in lockstep with the ruff run in CI.
 minimum_pre_commit_version: "3.5.0"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,5 +72,5 @@ PR descriptions follow the **newspaper / information-pyramid** format: one self-
 front page (kicker → headline → dek → masthead → why → what → mermaid flow → screens →
 verification → risk) that reads top-to-bottom on an iPad-mini portrait display (1–2 pages;
 up to 4 for very complex *code* changes). Rebuild from the **full** diff, never append.
-Full rules: <https://github.com/tommyroar/.github/blob/main/PR_FRAMEWORK.md>. CI validates
-the body via the `pr-newspaper` workflow (the reusable gate in `tommyroar/pr-newspaper`).
+Full rules: <https://github.com/robogeosociety/.github/blob/main/PR_FRAMEWORK.md>. CI validates
+the body via the `pr-newspaper` workflow (the reusable gate in `robogeosociety/pr-newspaper`).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # home-weather-hub
 
-Deployed dashboards · [grafana-local](https://github.com/tommyroar/home-weather-hub/deployments/grafana-local) · [grafana-tailnet](https://github.com/tommyroar/home-weather-hub/deployments/grafana-tailnet) · [influxdb-local](https://github.com/tommyroar/home-weather-hub/deployments/influxdb-local) · [influxdb-tailnet](https://github.com/tommyroar/home-weather-hub/deployments/influxdb-tailnet)
+Deployed dashboards · [grafana-local](https://github.com/robogeosociety/home-weather-hub/deployments/grafana-local) · [grafana-tailnet](https://github.com/robogeosociety/home-weather-hub/deployments/grafana-tailnet) · [influxdb-local](https://github.com/robogeosociety/home-weather-hub/deployments/influxdb-local) · [influxdb-tailnet](https://github.com/robogeosociety/home-weather-hub/deployments/influxdb-tailnet)
 
 Live home-climate observability for Tommy's house. Outdoor weather (Tempest UDP) and indoor Zigbee climate flow into a self-hosted **InfluxDB** on a Mac Mini, are visualized in **Grafana**, and are reachable from the LAN and over **Tailscale**.
 
@@ -36,7 +36,7 @@ Live data right now: Tempest `ST-00204728` writing one `obs_st` per 60s plus `ra
 | https://tommys-mac-mini.tail59a169.ts.net:3000/d/tempest-basic | Grafana dashboard, Tailscale |
 | http://tommys-mac-mini.local:8086/ | InfluxDB UI, LAN |
 | https://tommys-mac-mini.tail59a169.ts.net:8086/ | InfluxDB UI, Tailscale |
-| https://github.com/tommyroar/home-weather-hub/deployments | All four as clickable GitHub deployments |
+| https://github.com/robogeosociety/home-weather-hub/deployments | All four as clickable GitHub deployments |
 
 Credentials live in three chmod-600 `.env` files on the host (`/Volumes/dev/influxdb/.env`, `/Volumes/dev/grafana/.env`, `~/.local/share/tempest-bridge/.env`). They're gitignored. See [`infra/README.md`](infra/README.md) for layout, `.env.example` files, and reproducible setup from a clean machine.
 


### PR DESCRIPTION
`fleet` — **ORG RENAME**

Mechanical URL sweep after the tommyroar → robogeosociety org migration — README deployment links, CLAUDE.md PR-framework links, and the pre-commit + claude.yml source-of-truth comments. Old github.com URLs redirect, so this is canonical cleanup, not a fix; no Pages project URLs (the kind that hard-404) live in this repo.

## Verification
- `grep -rn tommyroar` — remaining hits: 0
- CI checks expected: ci.yml (ruff) on this PR

## Risk & rollout
- Comment/doc/URL-only (no logic change); redirects cover the transition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
